### PR TITLE
Made bower install a minimal front-end package, as NPM should be used to...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,17 @@
   "version": "0.3.12",
   "main": "ng-upload.js",
   "ignore": [
-    "**/.*",
     "node_modules",
-    "components"
+    "components",
+    "examples",
+    "libs",
+    "nuget",
+    "test",
+    ".bower.json",
+    "bower.json",
+    "Gruntfile.js",
+    "package.json",
+    "testacular.conf.js"
   ],
   "dependencies": {
     "jquery": "~1.9.1",


### PR DESCRIPTION
... build / debug.

The purpose of bower is to have a package that can be uploaded onto your webserver, you don't want tests, grunt build files, npm package lists, etc. All you need is the minified and un-minified source files and (perhaps) the changelog.
