### PR TITLE
Use innerText instead of innerHTML to ensure browser-included <pre> tags...

### DIFF
--- a/ng-upload.js
+++ b/ng-upload.js
@@ -106,7 +106,7 @@ angular.module('ngUpload', [])
                         // http://bugs.jquery.com/ticket/13936
                         var nativeIframe = iframe[0];
                         var iFrameDoc = nativeIframe.contentDocument || nativeIframe.contentWindow.document;
-                        var content = iFrameDoc.body.innerHTML;
+                        var content = iFrameDoc.body.innerText;
                         try {
                             content = JSON.parse(content);
                         } catch (e) {


### PR DESCRIPTION
... are not parsed.
