### PR TITLE
Unbind iframe after uploadEnd

### DIFF
--- a/ng-upload.js
+++ b/ng-upload.js
@@ -172,7 +172,7 @@ angular.module('ngUpload', [])
         // Finish upload
        function uploadEnd() {
           // unbind load after uploadEnd to prevent another load triggering uploadEnd
-          iframe.bind('load', uploadEnd);
+          iframe.unbind('load');
           if (!scope.$$phase) {
             scope.$apply(function() {
               setLoadingState(false);


### PR DESCRIPTION
When I upload a second file the uploadComplete function is called twice; with the third upload, uploadComplete function is called three times, and so on . Unbind "load" event of the iframe after upload fix the problem.
