### PR TITLE
Call `preventDefault` to cancel submit

### DIFF
--- a/ng-upload.js
+++ b/ng-upload.js
@@ -137,12 +137,18 @@ angular.module('ngUpload', [])
 
         setLoadingState(false);
         // Start upload
-        element.bind('submit', function uploadStart() {
+        element.bind('submit', function uploadStart($event) {
           var formController = scope[attrs.name];
           // if form is invalid don't submit (e.g. keypress 13)
-          if(formController && formController.$invalid) return false;
+          if(formController && formController.$invalid) {
+            $event.preventDefault();
+            return false;
+          }
           // perform check before submit file
-          if (options.beforeSubmit && options.beforeSubmit(scope, {}) === false) return false;
+          if (options.beforeSubmit && options.beforeSubmit(scope, {}) === false) {
+            $event.preventDefault();
+            return false;
+          }
 
           // bind load after submit to prevent initial load triggering uploadEnd
           iframe.bind('load', uploadEnd);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.3",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma": "~0.10.2",


### PR DESCRIPTION
While jQuery will cancel submit if the handler returns false, jqLite only stops submit if preventDefault is called.