### PR TITLE
Pass content to errorCatcher

### DIFF
--- a/ng-upload.js
+++ b/ng-upload.js
@@ -214,10 +214,10 @@ angular.module('ngUpload', [])
                 if ( errorCatcher ){
                    if (!scope.$$phase) {
                       scope.$apply(function () {
-                          errorCatcher(scope, { error: error});
+                          errorCatcher(scope, { error: error, content: content});
                       });
                    } else {
-                     errorCatcher(scope, { error: error});
+                     errorCatcher(scope, { error: error, content: content});
                    }
                 }
 


### PR DESCRIPTION
The problem I was seeing was that apache was returning an html page on
some errors and there was no way to actually get the body of the
response in errorCatcher since only the error ("Response is not valid
JSON") was available. I noticed there was a content variable already
so am passing it to errorCatcher.

This change should be backwards compatible since it's just adding a new argument to the errorCatcher call.
