### PR TITLE
Move grunt-bump package into devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.0",
+    "grunt-bump": "0.0.11",
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-watch": "~0.3.1",
@@ -33,6 +34,5 @@
     "grunt-karma": "~0.6.2"
   },
   "dependencies": {
-    "grunt-bump": "0.0.11"
   }
 }


### PR DESCRIPTION
When installing ngUpload in my project, `grunt-bump` is also installed since it's listed as a dependency. However, at `0.0.11`, `grunt-bump` lists `grunt` at `~0.4.0` as a peer dependency. 

------------------------------------
Grunt (as of version `1.0.0`) has since recommended:

```
      if you have a Grunt plugin that includes `grunt` in the `peerDependencies`,
      we recommend tagging with `"grunt": "">= 0.4.0"` and publishing a new version on npm.
```
[source](https://github.com/gruntjs/grunt/blob/master/CHANGELOG)

-------------------
My project uses Grunt version `1.0.1` and when I run `npm shrinkwrap` I get the following error:
`peer invalid: grunt@~0.4, required by grunt-bump@0.0.11`

I think the simplest and correct solution to this is to move the `grunt-bump` package into the devDependencies so it isn't installed as a node_module of the projects that use ngUpload. Also, it's only a dependency that's used during development so it seems like a win-win in that regard.

The other solution would be to bump the `grunt-bump` version up to the latest so that it doesn't have the unmet peer dependency issue (`grunt-bump` has since updated their Grunt peer dependency to be `>=1.0.1`).
